### PR TITLE
 feat: switch from cssauron to cssauron-noveal

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "stream"
   ],
   "dependencies": {
-    "cssauron": "1.4.0",
+    "cssauron-noeval": "1.4.0",
     "duplexer2": "0.0.2",
     "inherits": "2.0.3",
     "readable-stream": "2.3.6",

--- a/src/lang.js
+++ b/src/lang.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const cssauron = require('cssauron')
+const cssauron = require('cssauron-noeval')
 const getTag = require('./get_tag.js')
 const getAttr = require('./get_attr.js')
 


### PR DESCRIPTION
cssauron uses Function evaluation which is not always permitted. I created a version that uses a workaround for the eval. It should be compatible with most implementations (including this one), is more secure, and works on all engines.
